### PR TITLE
Introduce unit of work and minor fixes

### DIFF
--- a/src/DfE.ExternalApplications.Application/Users/QueryObjects/GetUserByEmailQueryObject.cs
+++ b/src/DfE.ExternalApplications.Application/Users/QueryObjects/GetUserByEmailQueryObject.cs
@@ -5,9 +5,9 @@ namespace DfE.ExternalApplications.Application.Users.QueryObjects
 {
     public class GetUserByEmailQueryObject(string email) : IQueryObject<User>
     {
-        private readonly string _email = email.Trim().ToLower();
+        private readonly string _email = email.Trim().ToLowerInvariant();
 
         public IQueryable<User> Apply(IQueryable<User> query) =>
-            query.Where(u => u.Email.ToLower() == _email);
+            query.Where(u => u.Email.ToLowerInvariant() == _email);
     }
 }

--- a/src/DfE.ExternalApplications.Domain/Entities/TaskAssignmentLabel.cs
+++ b/src/DfE.ExternalApplications.Domain/Entities/TaskAssignmentLabel.cs
@@ -13,4 +13,22 @@ public sealed class TaskAssignmentLabel : BaseAggregateRoot, IEntity<TaskAssignm
     public DateTime CreatedOn { get; private set; }
     public UserId CreatedBy { get; private set; }
     public User? CreatedByUser { get; private set; }
+
+    private TaskAssignmentLabel() { /* For EF Core */ }
+
+    public TaskAssignmentLabel(
+        TaskAssignmentLabelId id,
+        string value,
+        string taskId,
+        UserId createdBy,
+        DateTime? createdOn = null,
+        UserId? userId = null)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+        TaskId = taskId ?? throw new ArgumentNullException(nameof(taskId));
+        CreatedBy = createdBy;
+        CreatedOn = createdOn ?? DateTime.UtcNow;
+        UserId = userId;
+    }
 }

--- a/src/DfE.ExternalApplications.Domain/Interfaces/IUnitOfWork.cs
+++ b/src/DfE.ExternalApplications.Domain/Interfaces/IUnitOfWork.cs
@@ -1,0 +1,8 @@
+using System.Threading;
+using System.Threading.Tasks;
+namespace DfE.ExternalApplications.Domain.Interfaces;
+
+public interface IUnitOfWork
+{
+    Task<int> CommitAsync(CancellationToken cancellationToken = default);
+}

--- a/src/DfE.ExternalApplications.Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/DfE.ExternalApplications.Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using DfE.ExternalApplications.Domain.Interfaces.Repositories;
+using DfE.ExternalApplications.Domain.Interfaces;
+using DfE.ExternalApplications.Infrastructure;
 using DfE.ExternalApplications.Infrastructure.Database;
 using DfE.ExternalApplications.Infrastructure.Repositories;
 using DfE.ExternalApplications.Infrastructure.Security.Authorization;
@@ -14,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             //Repos
             services.AddScoped(typeof(IEaRepository<>), typeof(EaRepository<>));
+            services.AddScoped<IUnitOfWork, UnitOfWork>();
 
             //Cache service
             services.AddServiceCaching(config);

--- a/src/DfE.ExternalApplications.Infrastructure/Repositories/Repository.cs
+++ b/src/DfE.ExternalApplications.Infrastructure/Repositories/Repository.cs
@@ -99,7 +99,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
         public virtual TAggregate Add(TAggregate entity)
         {
             this.DbContext.Add<TAggregate>(entity);
-            this.DbContext.SaveChanges();
             return entity;
         }
 
@@ -107,7 +106,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
         public virtual async Task<TAggregate> AddAsync(TAggregate entity, CancellationToken cancellationToken = default(CancellationToken))
         {
             await this.DbContext.AddAsync<TAggregate>(entity, cancellationToken);
-            await this.DbContext.SaveChangesAsync(cancellationToken);
             return entity;
         }
 
@@ -115,7 +113,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
         public virtual IEnumerable<TAggregate> AddRange(ICollection<TAggregate> entities)
         {
             this.DbContext.AddRange((IEnumerable<object>)entities);
-            this.DbContext.SaveChanges();
             return (IEnumerable<TAggregate>)entities;
         }
 
@@ -125,7 +122,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
           CancellationToken cancellationToken = default(CancellationToken))
         {
             await this.DbContext.AddRangeAsync((IEnumerable<object>)entities, cancellationToken);
-            await this.DbContext.SaveChangesAsync(cancellationToken);
             return (IEnumerable<TAggregate>)entities;
         }
 
@@ -133,7 +129,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
         public virtual TAggregate Remove(TAggregate entity)
         {
             this.DbContext.Remove<TAggregate>(entity);
-            this.DbContext.SaveChanges();
             return entity;
         }
 
@@ -143,7 +138,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
           CancellationToken cancellationToken = default(CancellationToken))
         {
             this.DbContext.Remove<TAggregate>(entity);
-            await this.DbContext.SaveChangesAsync(cancellationToken);
             return entity;
         }
 
@@ -157,7 +151,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
         public virtual IEnumerable<TAggregate> RemoveRange(ICollection<TAggregate> entities)
         {
             this.DbSet().RemoveRange((IEnumerable<TAggregate>)entities);
-            this.DbContext.SaveChanges();
             return (IEnumerable<TAggregate>)entities;
         }
 
@@ -167,7 +160,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
           CancellationToken cancellationToken = default(CancellationToken))
         {
             this.DbSet().RemoveRange((IEnumerable<TAggregate>)entities);
-            await this.DbContext.SaveChangesAsync(cancellationToken);
             return (IEnumerable<TAggregate>)entities;
         }
 
@@ -175,7 +167,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
         public virtual TAggregate Update(TAggregate entity)
         {
             this.DbContext.Update<TAggregate>(entity);
-            this.DbContext.SaveChanges();
             return entity;
         }
 
@@ -185,7 +176,6 @@ namespace DfE.ExternalApplications.Infrastructure.Repositories
           CancellationToken cancellationToken = default(CancellationToken))
         {
             this.DbContext.Update<TAggregate>(entity);
-            await this.DbContext.SaveChangesAsync(cancellationToken);
             return entity;
         }
     }

--- a/src/DfE.ExternalApplications.Infrastructure/UnitOfWork.cs
+++ b/src/DfE.ExternalApplications.Infrastructure/UnitOfWork.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DfE.ExternalApplications.Domain.Interfaces;
+using DfE.ExternalApplications.Infrastructure.Database;
+
+namespace DfE.ExternalApplications.Infrastructure;
+
+public class UnitOfWork(ExternalApplicationsContext context) : IUnitOfWork
+{
+    public Task<int> CommitAsync(CancellationToken cancellationToken = default)
+        => context.SaveChangesAsync(cancellationToken);
+}


### PR DESCRIPTION
## Summary
- add a `IUnitOfWork` interface and implementation
- register the new unit of work in service collection
- stop calling `SaveChanges` in generic repository
- enforce invariants for `TaskAssignmentLabel`
- use `ToLowerInvariant` for normalising emails

