### PR TITLE
Add template schema endpoint

### DIFF
--- a/src/DfE.ExternalApplications.Api/Controllers/TemplatesController.cs
+++ b/src/DfE.ExternalApplications.Api/Controllers/TemplatesController.cs
@@ -1,0 +1,36 @@
+using Asp.Versioning;
+using DfE.ExternalApplications.Application.Templates.Models;
+using DfE.ExternalApplications.Application.Templates.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace DfE.ExternalApplications.Api.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("v{version:apiVersion}/[controller]")]
+public class TemplatesController(ISender sender) : ControllerBase
+{
+    /// <summary>
+    /// Returns the latest template schema for the specified template name if the user has access.
+    /// </summary>
+    [HttpGet("{templateName}/schema/{userId}")]
+    [SwaggerResponse(200, "The latest template schema.", typeof(TemplateSchemaDto))]
+    [SwaggerResponse(400, "Request was invalid or access denied.")]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetLatestTemplateSchemaAsync(
+        [FromRoute] string templateName,
+        [FromRoute] Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var query = new GetLatestTemplateSchemaQuery(templateName, userId);
+        var result = await sender.Send(query, cancellationToken);
+
+        if (!result.IsSuccess)
+            return BadRequest(result.Error);
+
+        return Ok(result.Value);
+    }
+}

--- a/src/DfE.ExternalApplications.Application/Templates/Models/TemplateSchemaDto.cs
+++ b/src/DfE.ExternalApplications.Application/Templates/Models/TemplateSchemaDto.cs
@@ -1,0 +1,7 @@
+namespace DfE.ExternalApplications.Application.Templates.Models;
+
+public class TemplateSchemaDto
+{
+    public required string VersionNumber { get; set; }
+    public required string JsonSchema { get; set; }
+}

--- a/src/DfE.ExternalApplications.Application/Templates/Queries/GetLatestTemplateSchemaQueryHandler.cs
+++ b/src/DfE.ExternalApplications.Application/Templates/Queries/GetLatestTemplateSchemaQueryHandler.cs
@@ -1,0 +1,67 @@
+using DfE.CoreLibs.Caching.Helpers;
+using DfE.CoreLibs.Caching.Interfaces;
+using DfE.ExternalApplications.Application.Templates.Models;
+using DfE.ExternalApplications.Application.Templates.QueryObjects;
+using DfE.ExternalApplications.Domain.Entities;
+using DfE.ExternalApplications.Domain.Interfaces.Repositories;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.ExternalApplications.Application.Templates.Queries;
+
+public sealed record GetLatestTemplateSchemaQuery(string TemplateName, Guid UserId)
+    : IRequest<Result<TemplateSchemaDto>>;
+
+public sealed class GetLatestTemplateSchemaQueryHandler(
+    IEaRepository<UserTemplateAccess> accessRepo,
+    IEaRepository<TemplateVersion> versionRepo,
+    ICacheService<IMemoryCacheType> cacheService)
+    : IRequestHandler<GetLatestTemplateSchemaQuery, Result<TemplateSchemaDto>>
+{
+    public async Task<Result<TemplateSchemaDto>> Handle(
+        GetLatestTemplateSchemaQuery request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var cacheKey = $"TemplateSchema_{CacheKeyHelper.GenerateHashedCacheKey(request.TemplateName)}_{request.UserId}";
+            var methodName = nameof(GetLatestTemplateSchemaQueryHandler);
+
+            return await cacheService.GetOrAddAsync(
+                cacheKey,
+                async () =>
+                {
+                    var access = await new GetUserTemplateAccessByTemplateNameQueryObject(request.UserId, request.TemplateName)
+                        .Apply(accessRepo.Query().AsNoTracking())
+                        .FirstOrDefaultAsync(cancellationToken);
+
+                    if (access is null)
+                    {
+                        return Result<TemplateSchemaDto>.Failure("Access denied");
+                    }
+
+                    var latest = await new GetLatestTemplateVersionForTemplateQueryObject(access.TemplateId)
+                        .Apply(versionRepo.Query().AsNoTracking())
+                        .FirstOrDefaultAsync(cancellationToken);
+
+                    if (latest is null)
+                    {
+                        return Result<TemplateSchemaDto>.Failure("Template version not found");
+                    }
+
+                    var dto = new TemplateSchemaDto
+                    {
+                        VersionNumber = latest.VersionNumber,
+                        JsonSchema = latest.JsonSchema
+                    };
+
+                    return Result<TemplateSchemaDto>.Success(dto);
+                },
+                methodName);
+        }
+        catch (Exception e)
+        {
+            return Result<TemplateSchemaDto>.Failure(e.ToString());
+        }
+    }
+}

--- a/src/DfE.ExternalApplications.Application/Templates/QueryObjects/GetLatestTemplateVersionForTemplateQueryObject.cs
+++ b/src/DfE.ExternalApplications.Application/Templates/QueryObjects/GetLatestTemplateVersionForTemplateQueryObject.cs
@@ -1,0 +1,17 @@
+using DfE.ExternalApplications.Application.Common.QueriesObjects;
+using DfE.ExternalApplications.Domain.Entities;
+using DfE.ExternalApplications.Domain.ValueObjects;
+
+namespace DfE.ExternalApplications.Application.Templates.QueryObjects;
+
+public sealed class GetLatestTemplateVersionForTemplateQueryObject(TemplateId templateId)
+    : IQueryObject<TemplateVersion>
+{
+    private readonly TemplateId _templateId = templateId;
+
+    public IQueryable<TemplateVersion> Apply(IQueryable<TemplateVersion> query) =>
+        query
+            .Where(tv => tv.TemplateId == _templateId)
+            .OrderByDescending(tv => tv.CreatedOn)
+            .Take(1);
+}

--- a/src/DfE.ExternalApplications.Application/Templates/QueryObjects/GetUserTemplateAccessByTemplateNameQueryObject.cs
+++ b/src/DfE.ExternalApplications.Application/Templates/QueryObjects/GetUserTemplateAccessByTemplateNameQueryObject.cs
@@ -1,0 +1,18 @@
+using DfE.ExternalApplications.Application.Common.QueriesObjects;
+using DfE.ExternalApplications.Domain.Entities;
+using DfE.ExternalApplications.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.ExternalApplications.Application.Templates.QueryObjects;
+
+public sealed class GetUserTemplateAccessByTemplateNameQueryObject(Guid userId, string templateName)
+    : IQueryObject<UserTemplateAccess>
+{
+    private readonly UserId _userId = new(userId);
+    private readonly string _normalizedName = templateName.Trim().ToLowerInvariant();
+
+    public IQueryable<UserTemplateAccess> Apply(IQueryable<UserTemplateAccess> query) =>
+        query
+            .Include(x => x.Template)
+            .Where(x => x.UserId == _userId && x.Template!.Name.ToLower() == _normalizedName);
+}

--- a/src/Tests/DfE.ExternalApplications.Api.Tests.Integration/Controllers/TemplatesControllerTests.cs
+++ b/src/Tests/DfE.ExternalApplications.Api.Tests.Integration/Controllers/TemplatesControllerTests.cs
@@ -1,0 +1,50 @@
+using DfE.CoreLibs.Testing.AutoFixture.Attributes;
+using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
+using DfE.ExternalApplications.Infrastructure.Database;
+using DfE.ExternalApplications.Tests.Common.Customizations;
+using DfE.ExternalApplications.Domain.Entities;
+using DfE.ExternalApplications.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using System.Net.Http.Json;
+
+namespace DfE.ExternalApplications.Api.Tests.Integration.Controllers;
+
+public class TemplatesControllerTests
+{
+    [Theory]
+    [CustomAutoData(typeof(CustomWebApplicationDbContextFactoryCustomization))]
+    public async Task GetLatestTemplateSchemaAsync_ReturnsLatestSchema_WhenUserHasAccess(
+        CustomWebApplicationDbContextFactory<Program> factory,
+        HttpClient client)
+    {
+        var dbContext = factory.GetDbContext<ExternalApplicationsContext>();
+
+        var template = await dbContext.Templates.FirstAsync();
+        var userAccess = await dbContext.UserTemplateAccesses.FirstAsync();
+
+        // add a newer version
+        var latestVersion = await dbContext.TemplateVersions
+            .Where(tv => tv.TemplateId == template.Id)
+            .OrderByDescending(tv => tv.CreatedOn)
+            .FirstAsync();
+
+        var newVersion = new TemplateVersion(
+            new TemplateVersionId(Guid.NewGuid()),
+            template.Id,
+            versionNumber: "v9.9",
+            jsonSchema: "{\"new\":true}",
+            createdOn: DateTime.UtcNow.AddMinutes(1),
+            createdBy: latestVersion.CreatedBy);
+
+        dbContext.TemplateVersions.Add(newVersion);
+        await dbContext.SaveChangesAsync();
+
+        var response = await client.GetAsync($"v1/Templates/{Uri.EscapeDataString(template.Name)}/schema/{userAccess.UserId.Value}");
+        response.EnsureSuccessStatusCode();
+        var dto = await response.Content.ReadFromJsonAsync<DfE.ExternalApplications.Application.Templates.Models.TemplateSchemaDto>();
+
+        Assert.NotNull(dto);
+        Assert.Equal("v9.9", dto!.VersionNumber);
+        Assert.Equal("{\"new\":true}", dto.JsonSchema);
+    }
+}

--- a/src/Tests/DfE.ExternalApplications.Application.Tests/QueryHandlers/Templates/GetLatestTemplateSchemaQueryHandlerTests.cs
+++ b/src/Tests/DfE.ExternalApplications.Application.Tests/QueryHandlers/Templates/GetLatestTemplateSchemaQueryHandlerTests.cs
@@ -1,0 +1,68 @@
+using AutoFixture;
+using AutoFixture.Xunit2;
+using DfE.CoreLibs.Caching.Interfaces;
+using DfE.CoreLibs.Testing.AutoFixture.Attributes;
+using DfE.ExternalApplications.Application.Templates.Models;
+using DfE.ExternalApplications.Application.Templates.Queries;
+using DfE.ExternalApplications.Domain.Entities;
+using DfE.ExternalApplications.Domain.Interfaces.Repositories;
+using DfE.ExternalApplications.Domain.ValueObjects;
+using DfE.ExternalApplications.Tests.Common.Customizations.Entities;
+using MockQueryable;
+using NSubstitute;
+
+namespace DfE.ExternalApplications.Application.Tests.QueryHandlers.Templates;
+
+public class GetLatestTemplateSchemaQueryHandlerTests
+{
+    [Theory, CustomAutoData(typeof(UserTemplateAccessCustomization), typeof(TemplateVersionCustomization))]
+    public async Task Handle_ShouldReturnLatestSchema_WhenUserHasAccess(
+        UserTemplateAccessCustomization utaCustom,
+        TemplateVersionCustomization tvCustom,
+        [Frozen] IEaRepository<UserTemplateAccess> accessRepo,
+        [Frozen] IEaRepository<TemplateVersion> versionRepo,
+        [Frozen] ICacheService<IMemoryCacheType> cacheService)
+    {
+        var template = new Fixture().Customize(new TemplateCustomization()).Create<Template>();
+        utaCustom.OverrideTemplateId = template.Id;
+        var fixture = new Fixture().Customize(utaCustom);
+        var access = fixture.Create<UserTemplateAccess>();
+        typeof(UserTemplateAccess).GetProperty(nameof(UserTemplateAccess.Template))!.SetValue(access, template);
+
+        var userId = access.UserId;
+        var templateName = template.Name;
+
+        var accessQ = new List<UserTemplateAccess> { access }.AsQueryable().BuildMock();
+        accessRepo.Query().Returns(accessQ);
+
+        tvCustom.OverrideTemplateId = template.Id;
+        tvCustom.OverrideCreatedOn = DateTime.UtcNow.AddDays(-1);
+        var older = new Fixture().Customize(tvCustom).Create<TemplateVersion>();
+        var newerCustomization = new TemplateVersionCustomization
+        {
+            OverrideTemplateId = template.Id,
+            OverrideCreatedOn = DateTime.UtcNow
+        };
+        var newer = new Fixture().Customize(newerCustomization).Create<TemplateVersion>();
+
+        var tvList = new List<TemplateVersion> { older, newer };
+        var tvQ = tvList.AsQueryable().BuildMock();
+        versionRepo.Query().Returns(tvQ);
+
+        var cacheKey = $"TemplateSchema_{DfE.CoreLibs.Caching.Helpers.CacheKeyHelper.GenerateHashedCacheKey(templateName)}_{userId.Value}";
+        cacheService
+            .GetOrAddAsync(cacheKey, Arg.Any<Func<Task<Result<TemplateSchemaDto>>>>(), nameof(GetLatestTemplateSchemaQueryHandler))
+            .Returns(call =>
+            {
+                var factory = call.Arg<Func<Task<Result<TemplateSchemaDto>>>>();
+                return factory();
+            });
+
+        var handler = new GetLatestTemplateSchemaQueryHandler(accessRepo, versionRepo, cacheService);
+        var result = await handler.Handle(new GetLatestTemplateSchemaQuery(templateName, userId.Value), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(newer.JsonSchema, result.Value!.JsonSchema);
+        Assert.Equal(newer.VersionNumber, result.Value!.VersionNumber);
+    }
+}

--- a/src/Tests/DfE.ExternalApplications.Application.Tests/QueryObjects/Templates/GetLatestTemplateVersionForTemplateQueryObjectTests.cs
+++ b/src/Tests/DfE.ExternalApplications.Application.Tests/QueryObjects/Templates/GetLatestTemplateVersionForTemplateQueryObjectTests.cs
@@ -1,0 +1,38 @@
+using AutoFixture;
+using DfE.CoreLibs.Testing.AutoFixture.Attributes;
+using DfE.ExternalApplications.Application.Templates.QueryObjects;
+using DfE.ExternalApplications.Domain.Entities;
+using DfE.ExternalApplications.Domain.ValueObjects;
+using DfE.ExternalApplications.Tests.Common.Customizations.Entities;
+
+namespace DfE.ExternalApplications.Application.Tests.QueryObjects.Templates;
+
+public class GetLatestTemplateVersionForTemplateQueryObjectTests
+{
+    [Theory, CustomAutoData(typeof(TemplateVersionCustomization))]
+    public void Apply_ShouldReturnLatestVersion_ForTemplate(
+        TemplateVersionCustomization tvCustom)
+    {
+        var templateId = new TemplateId(Guid.NewGuid());
+
+        tvCustom.OverrideTemplateId = templateId;
+        tvCustom.OverrideCreatedOn = DateTime.UtcNow.AddDays(-1);
+        var fixture = new Fixture().Customize(tvCustom);
+        var older = fixture.Create<TemplateVersion>();
+
+        var newerCustomization = new TemplateVersionCustomization
+        {
+            OverrideTemplateId = templateId,
+            OverrideCreatedOn = DateTime.UtcNow
+        };
+        var newer = new Fixture().Customize(newerCustomization).Create<TemplateVersion>();
+
+        var list = new List<TemplateVersion> { older, newer };
+
+        var sut = new GetLatestTemplateVersionForTemplateQueryObject(templateId);
+        var result = sut.Apply(list.AsQueryable()).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(newer, result[0]);
+    }
+}

--- a/src/Tests/DfE.ExternalApplications.Application.Tests/QueryObjects/Templates/GetUserTemplateAccessByTemplateNameQueryObjectTests.cs
+++ b/src/Tests/DfE.ExternalApplications.Application.Tests/QueryObjects/Templates/GetUserTemplateAccessByTemplateNameQueryObjectTests.cs
@@ -1,0 +1,55 @@
+using AutoFixture;
+using AutoFixture.Xunit2;
+using DfE.CoreLibs.Testing.AutoFixture.Attributes;
+using DfE.ExternalApplications.Application.Templates.QueryObjects;
+using DfE.ExternalApplications.Domain.Entities;
+using DfE.ExternalApplications.Domain.ValueObjects;
+using DfE.ExternalApplications.Tests.Common.Customizations.Entities;
+
+namespace DfE.ExternalApplications.Application.Tests.QueryObjects.Templates;
+
+public class GetUserTemplateAccessByTemplateNameQueryObjectTests
+{
+    [Theory, CustomAutoData(typeof(UserTemplateAccessCustomization), typeof(TemplateCustomization))]
+    public void Apply_ShouldReturnMatchingAccess_WhenUserAndTemplateNameMatch(
+        Guid userGuid,
+        string templateName,
+        UserTemplateAccessCustomization accessCustom,
+        TemplateCustomization templateCustom,
+        [Frozen] IList<UserTemplateAccess> accessList)
+    {
+        templateCustom.OverrideName = templateName;
+        var fixture = new Fixture().Customize(templateCustom);
+        var template = fixture.Create<Template>();
+
+        accessCustom.OverrideUserId = new UserId(userGuid);
+        accessCustom.OverrideTemplateId = template.Id;
+        var fixtureAccess = new Fixture().Customize(accessCustom);
+        var matching = fixtureAccess.Create<UserTemplateAccess>();
+
+        // attach template via reflection
+        typeof(UserTemplateAccess)
+            .GetProperty(nameof(UserTemplateAccess.Template))!
+            .SetValue(matching, template);
+
+        var otherTemplate = new Fixture().Customize(new TemplateCustomization()).Create<Template>();
+        var otherAccess = new Fixture().Customize(new UserTemplateAccessCustomization
+        {
+            OverrideUserId = new UserId(Guid.NewGuid()),
+            OverrideTemplateId = otherTemplate.Id
+        }).Create<UserTemplateAccess>();
+        typeof(UserTemplateAccess)
+            .GetProperty(nameof(UserTemplateAccess.Template))!
+            .SetValue(otherAccess, otherTemplate);
+
+        accessList.Clear();
+        accessList.Add(matching);
+        accessList.Add(otherAccess);
+
+        var sut = new GetUserTemplateAccessByTemplateNameQueryObject(userGuid, templateName);
+        var result = sut.Apply(accessList.AsQueryable()).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(matching, result[0]);
+    }
+}

--- a/src/Tests/DfE.ExternalApplications.Application.Tests/SecurityTests/ExpectedSecurity.json
+++ b/src/Tests/DfE.ExternalApplications.Application.Tests/SecurityTests/ExpectedSecurity.json
@@ -4,6 +4,11 @@
       "Controller": "UsersController",
       "Action": "GetAllPermissionsForUserAsync",
       "ExpectedSecurity": "AllowAnonymous"
+    },
+    {
+      "Controller": "TemplatesController",
+      "Action": "GetLatestTemplateSchemaAsync",
+      "ExpectedSecurity": "AllowAnonymous"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `TemplatesController` with GetLatestTemplateSchema endpoint
- add Template query objects and query handler
- add TemplateSchemaDto
- tests for query objects, query handler, and controller
- update security expectations

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e6bae6708333af24a7d9a4c8b0ec