### PR TITLE
Add Visits config section to appsettings files

### DIFF
--- a/src/DfE.ExternalApplications.Api/appsettings.Development.json
+++ b/src/DfE.ExternalApplications.Api/appsettings.Development.json
@@ -245,7 +245,7 @@
         "DiscoveryEndpoint": "https://test-oidc.signin.education.gov.uk/.well-known/openid-configuration"
       },
       "TestAuthentication": {
-        "Enabled": true,
+        "Enabled": false,
         "JwtSigningKey": "secret",
         "JwtIssuer": "test-external-applications",
         "JwtAudience": "external-applications-api"
@@ -290,6 +290,14 @@
           }
         ],
         "TokenLifetimeMinutes": 60
+      },
+      "EntraSso": {
+        "Enabled": true,
+        "Instance": "https://login.microsoftonline.com/",
+        "TenantId": "fad277c9-c60a-4da1-b5f3-b3b8b34a82f9",
+        "ClientId": "30067021-f76a-405f-8aeb-96d07f5bc080",
+        "Scopes": [ "openid", "profile", "email" ],
+        "AllowedGroupId": ""
       }
     }
   }

--- a/src/DfE.ExternalApplications.Api/appsettings.Development.json
+++ b/src/DfE.ExternalApplications.Api/appsettings.Development.json
@@ -199,6 +199,98 @@
         "Scopes": [ "openid", "profile", "email" ],
         "AllowedGroupId": ""
       }
+    },
+    "Visits": {
+      "Id": "33333333-3333-4333-8333-333333333333",
+      "Name": "Visits",
+      "ApplicationReference": {
+        "Prefix": "VST"
+      },
+      "Logging": {
+        "LogLevel": {
+          "Default": "Warning",
+          "Microsoft": "Information",
+          "Microsoft.Hosting.Lifetime": "Information",
+          "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+        },
+        "Console": {
+          "FormatterName": "simple",
+          "FormatterOptions": {
+            "IncludeScopes": true
+          }
+        }
+      },
+      "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost,1433;Database=ExternalApplications;User Id=SA;Password=YourPassword123!;TrustServerCertificate=True;",
+        "AzureSignalR": "",
+        "Redis": "localhost:6379",
+        "ServiceBus": "Endpoint=sb://dummy.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=dummy"
+      },
+      "AllowedHosts": "*",
+      "AzureAd": {
+        "Instance": "https://login.microsoftonline.com/",
+        "Domain": "platform.education.gov.uk",
+        "TenantId": "9c7d9dd3-840c-4b3f-818e-552865082e16",
+        "ClientId": "65c013ab-cc5d-4fd9-8797-e81c5b16eb3e",
+        "Audience": "api://65c013ab-cc5d-4fd9-8797-e81c5b16eb3e"
+      },
+      "Features": {
+        "PerformanceLoggingEnabled": false
+      },
+      "DfESignIn": {
+        "Authority": "https://test-oidc.signin.education.gov.uk",
+        "ClientId": "localSENDReformPlans",
+        "Issuer": "https://test-oidc.signin.education.gov.uk:443",
+        "JwksUri": "https://test-oidc.signin.education.gov.uk/jwks",
+        "DiscoveryEndpoint": "https://test-oidc.signin.education.gov.uk/.well-known/openid-configuration"
+      },
+      "TestAuthentication": {
+        "Enabled": true,
+        "JwtSigningKey": "secret",
+        "JwtIssuer": "test-external-applications",
+        "JwtAudience": "external-applications-api"
+      },
+      "Frontend": {
+        "Origin": "https://dev.to-do.education.gov.uk/"
+      },
+      "SkipMassTransit": false,
+      "MassTransit": {
+        "Transport": "AzureServiceBus",
+        "AppPrefix": "",
+        "AzureServiceBus": {
+          "ConnectionString": "",
+          "AutoCreateEntities": false,
+          "ConfigureEndpoints": false,
+          "UseWebSockets": true,
+          "InstanceIdentifier": "auto",
+          "SubscriptionName": "extapi"
+        }
+      },
+      "FileStorage": {
+        "Azure": {
+          "ShareName": "s184d01-extapi-storage"
+        }
+      },
+      "FrontendSettings": {
+        "BaseUrl": "https://dev.to-do.education.gov.uk/",
+        "PreviewContentSelector": ".govuk-grid-column-full"
+      },
+      "Email": {
+        "ServiceSupportEmailAddress": "Farshad.DASHTI@education.gov.uk"
+      },
+      "InternalServiceAuth": {
+        "Services": [
+          {
+            "Email": "eat-visits-service@service.com",
+            "ApiKey": "secret"
+          },
+          {
+            "Email": "eat-cypress-vists-service@service.com",
+            "ApiKey": "secret"
+          }
+        ],
+        "TokenLifetimeMinutes": 60
+      }
     }
   }
 }

--- a/src/DfE.ExternalApplications.Api/appsettings.json
+++ b/src/DfE.ExternalApplications.Api/appsettings.json
@@ -417,6 +417,214 @@
         "Scopes": [ "openid", "profile", "email" ],
         "AllowedGroupId": ""
       }
+    },
+    "Visits": {
+      "Id": "33333333-3333-4333-8333-333333333333",
+      "Name": "LSRP",
+      "ApplicationReference": {
+        "Prefix": "VST"
+      },
+      "AllowedHosts": "*",
+      "ApplicationInsights": {
+        "ConnectionString": "Copy connection string from Application Insights Resource Overview"
+      },
+      "Authorization": {
+        "Policies": [
+          {
+            "Name": "SvcCanRead",
+            "Operator": "OR",
+            "Roles": [ "API.Read" ]
+          },
+          {
+            "Name": "SvcCanReadWrite",
+            "Operator": "AND",
+            "Roles": [ "API.Read", "API.Write" ]
+          },
+          {
+            "Name": "SvcCanReadWriteDelete",
+            "Operator": "AND",
+            "Roles": [ "API.Read", "API.Write", "API.Delete" ]
+          },
+          {
+            "Name": "IsAdmin",
+            "Operator": "AND",
+            "Roles": [ "Admin" ]
+          }
+        ],
+        "TokenSettings": {
+          "SecretKey": "replace-this-with-a-secure-32-char-key!",
+          "Issuer": "c06ca515-122d-45b7-b40b-513ace7009bd",
+          "Audience": "25f087cf-637d-4894-bc4f-37ffaeda447b",
+          "TokenLifetimeMinutes": 60
+        }
+      },
+      "InternalServiceAuth": {
+        "Services": [
+          {
+            "Email": "eat-visits-service@service.com",
+            "ApiKey": "replace-with-secure-api-key-here!"
+          }
+        ],
+        "SecretKey": "replace-this-internal-auth-32-char-key!",
+        "Issuer": "external-applications-visits",
+        "Audience": "external-applications-api",
+        "TokenLifetimeMinutes": 10
+      },
+      "CacheSettings": {
+        "Memory": {
+          "DefaultDurationInSeconds": 60,
+          "Durations": {
+            "GetApplicationsForUserQueryHandler": 1,
+            "GetApplicationsForUserByExternalProviderIdQueryHandler": 1,
+            "UserPermissionClaimProvider": 600
+          }
+        },
+        "Redis": {
+          "KeyPrefix": "DfE:Cache:",
+          "DefaultDurationInSeconds": 60,
+          "Durations": {
+            "GetApplicationsForUserQueryHandler": 1,
+            "GetApplicationsForUserByExternalProviderIdQueryHandler": 1,
+            "UserPermissionClaimProvider": 600
+          }
+        }
+      },
+      "FeatureManagement": {
+      },
+      "Logging": {
+        "LogLevel": {
+          "Default": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Warning",
+          "Microsoft.AspNetCore": "Warning"
+        },
+        "Console": {
+          "FormatterName": "simple",
+          "FormatterOptions": {
+            "IncludeScopes": true
+          }
+        }
+      },
+      "Serilog": {
+        "Using": [
+          "Serilog.Sinks.ApplicationInsights"
+        ],
+        "MinimumLevel": {
+          "Default": "Warning",
+          "Override": {
+            "Microsoft": "Warning",
+            "System": "Warning"
+          }
+        },
+        "Enrich": [ "FromLogContext" ],
+        "Properties": {
+          "Application": "DfE.ExternalApplications.Api"
+        }
+      },
+      "FileStorage": {
+        "Provider": "Hybrid",
+        "Local": {
+          "BaseDirectory": "/uploads",
+          "CreateDirectoryIfNotExists": true,
+          "AllowOverwrite": true,
+          "MaxFileSizeBytes": 10000000,
+          "AllowedExtensions": [ "jpg", "png", "pdf", "docx", "xlsx" ],
+          "AllowedFileNamePattern": "^[\\sa-zA-Z0-9_-]+$",
+          "AllowedFileNamePatternFriendlyList": "a-z A-Z 0-9 _ - space"
+        },
+        "Azure": {
+          "ConnectionString": "Secret",
+          "ShareName": "s184d01-extapi-storage"
+        }
+      },
+      "NotificationService": {
+        "StorageProvider": "Redis",
+        "MaxNotificationsPerUser": 50,
+        "AutoCleanupIntervalMinutes": 60,
+        "MaxNotificationAgeHours": 24,
+        "RedisConnectionString": "localhost:1111",
+        "RedisKeyPrefix": "visits-notifications:",
+        "TypeDefaults": {
+          "Success": {
+            "AutoDismiss": true,
+            "AutoDismissSeconds": 5
+          },
+          "Error": {
+            "AutoDismiss": false,
+            "AutoDismissSeconds": 10
+          },
+          "Info": {
+            "AutoDismiss": true,
+            "AutoDismissSeconds": 5
+          },
+          "Warning": {
+            "AutoDismiss": true,
+            "AutoDismissSeconds": 7
+          }
+        }
+      },
+      "Email": {
+        "Provider": "GovUkNotify",
+        "ServiceSupportEmailAddress": "",
+        "GovUkNotify": {
+          "ApiKey": "secret",
+          "BaseUrl": "https://api.notifications.service.gov.uk",
+          "TimeoutSeconds": 30,
+          "UseProxy": false,
+          "MaxAttachmentSize": 2097152,
+          "AllowedAttachmentTypes": [ ".pdf", ".csv", ".txt", ".doc", ".docx", ".xls", ".xlsx", ".rtf", ".odt", ".ods", ".odp" ]
+        }
+      },
+      "ApplicationTemplates": {
+        "HostMappings": {
+          "transfers": "9A4E9C58-9135-468C-B154-7B966F7ACFB7",
+          "lsrp": "B2F8E7D4-2C46-4A91-8E73-9D5A1F4B6C89",
+          "visits": "413752f0-d67d-408f-b8eb-39ac02e7a612"
+        }
+      },
+      "EmailTemplates": {
+        "Transfer": {
+          "ApplicationSubmitted": "a4188604-0053-4d77-9ad2-720f6fbbdf0a",
+          "ContributorInvited": "3a0e2130-ceea-48c9-8e3d-906431acc86f",
+          "BugReportInternal": "8b51948c-d7d1-4a26-8ea6-f4a78a27ce5a",
+          "BugReportUser": "6b0c7eb1-ec0b-4e6e-91e0-92c602ede7d8",
+          "SupportRequestInternal": "d6577f06-cedd-4bb1-8274-a5399c5e7056",
+          "SupportRequestUser": "2abe75fc-b772-4a02-89c2-0069f56a49b7",
+          "FeedbackOrSuggestionInternal": "73f684f4-875c-4d4b-b88a-b73f5f1e7c5b"
+        },
+        "Lsrp": {
+          "ApplicationSubmitted": "c6300826-2275-6f99-bf40-9d188h9ceh2c",
+          "ContributorInvited": "3a0e2130-ceea-48c9-8e3d-906431acc86f",
+          "StatusChanged": "e8522048-4497-8h11-dh62-bf300j1egk4e"
+        },
+        "Visits": {
+          "ApplicationSubmitted": "c6300826-2275-6f99-bf40-9d188h9ceh2c",
+          "ContributorInvited": "3a0e2130-ceea-48c9-8e3d-906431acc86f",
+          "StatusChanged": "e8522048-4497-8h11-dh62-bf300j1egk4e"
+        }
+      },
+      "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost,1433;Database=ExternalApplications;User Id=SA;Password=YourPassword123!;TrustServerCertificate=True;",
+        "AzureSignalR": "",
+        "Redis": "localhost:6379",
+        "ServiceBus": "Endpoint=sb://dummy.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=dummy"
+      },
+      "FrontendSettings": {
+        "BaseUrl": "https://localhost:5001",
+        "PreviewContentSelector": "govuk-grid-column-full"
+      },
+      "DfESignIn": {
+        "Authority": "https://test-oidc.signin.education.gov.uk",
+        "ClientId": "localSENDReformPlans",
+        "Issuer": "https://test-oidc.signin.education.gov.uk:443",
+        "DiscoveryEndpoint": "https://test-oidc.signin.education.gov.uk/.well-known/openid-configuration"
+      },
+      "AzureAd": {
+        "Instance": "https://login.microsoftonline.com/",
+        "TenantId": "common",
+        "ClientId": "default-client",
+        "Audience": "api://default-client"
+      }
     }
   }
 }


### PR DESCRIPTION
Add Visits config section to appsettings files

Introduced a comprehensive Visits section in both appsettings.json and appsettings.Development.json. This includes settings for identity, logging, connection strings, authentication, authorization, caching, feature flags, file storage, notifications, email, templates, and integrations. appsettings.json contains additional details such as policies, cache, and template configurations.