### PR TITLE
Add RG Visits prod config and bump version to 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,5 +84,9 @@ All notable changes to this service will be documented in this file.
 ### Notes
 - Improved GetApplicationByReference query performance
 
+## [1.3.3] - Public Beta
+### Notes
+- - Added RG Visits Prod env appsettings
+
 
 

--- a/src/DfE.ExternalApplications.Api/DfE.ExternalApplications.Api.csproj
+++ b/src/DfE.ExternalApplications.Api/DfE.ExternalApplications.Api.csproj
@@ -5,8 +5,8 @@
 		<NoWarn>$(NoWarn);1591</NoWarn>
 		<TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>f714ca7a-fc08-46ff-b0cc-373d6f04cf4c</UserSecretsId>
-	  <Version>1.3.2</Version>
-	  <InformationalVersion>1.3.2</InformationalVersion>
+	  <Version>1.3.3</Version>
+	  <InformationalVersion>1.3.3</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DfE.ExternalApplications.Api/appsettings.Production.json
+++ b/src/DfE.ExternalApplications.Api/appsettings.Production.json
@@ -151,6 +151,83 @@
       "Email": {
         "ServiceSupportEmailAddress": "RegionalServices.RG@education.gov.uk"
       }
+    },
+    "Visits": {
+      "Id": "33333333-3333-4333-8333-333333333333",
+      "Name": "Visits",
+      "ApplicationReference": {
+        "Prefix": "VST"
+      },
+      "Logging": {
+        "LogLevel": {
+          "Default": "Warning",
+          "Microsoft": "Information",
+          "Microsoft.Hosting.Lifetime": "Information"
+        },
+        "Console": {
+          "FormatterName": "simple",
+          "FormatterOptions": {
+            "IncludeScopes": true
+          }
+        }
+      },
+      "ConnectionStrings": {
+        "DefaultConnection": "",
+        "AzureSignalR": "",
+        "Redis": "localhost:6379"
+      },
+      "AllowedHosts": "*",
+      "AzureAd": {
+        "Instance": "https://login.microsoftonline.com/",
+        "Domain": "platform.education.gov.uk",
+        "TenantId": "9c7d9dd3-840c-4b3f-818e-552865082e16",
+        "ClientId": "547b0a35-2d35-4ba0-ba57-02a8b264f635",
+        "Audience": "api://547b0a35-2d35-4ba0-ba57-02a8b264f635"
+      },
+      "Features": {
+        "PerformanceLoggingEnabled": false
+      },
+      "TestAuthentication": {
+        "Enabled": false,
+        "JwtSigningKey": "secret",
+        "JwtIssuer": "test-external-applications",
+        "JwtAudience": "external-applications-api"
+      },
+      "Frontend": {
+        "Origin": "https://record-engagement-with-education-providers.education.gov.uk/"
+      },
+      "SkipMassTransit": false,
+      "MassTransit": {
+        "Transport": "AzureServiceBus",
+        "AppPrefix": "",
+        "AzureServiceBus": {
+          "ConnectionString": "",
+          "AutoCreateEntities": false,
+          "ConfigureEndpoints": false,
+          "UseWebSockets": true,
+          "InstanceIdentifier": "auto"
+        }
+      },
+      "FileStorage": {
+        "Azure": {
+          "ShareName": "s184p01-extapi-storage"
+        }
+      },
+      "FrontendSettings": {
+        "BaseUrl": "https://record-engagement-with-education-providers.education.gov.uk",
+        "PreviewContentSelector": ".govuk-grid-column-full"
+      },
+      "Email": {
+        "ServiceSupportEmailAddress": "RegionalServices.RG@education.gov.uk"
+      },
+      "EntraSso": {
+        "Enabled": true,
+        "Instance": "https://login.microsoftonline.com/",
+        "TenantId": "fad277c9-c60a-4da1-b5f3-b3b8b34a82f9",
+        "ClientId": "66fcc8e7-e758-4b0d-9719-bf9244a08487",
+        "Scopes": [ "openid", "profile", "email" ],
+        "AllowedGroupId": ""
+      }
     }
 
   }

--- a/src/DfE.ExternalApplications.Api/appsettings.json
+++ b/src/DfE.ExternalApplications.Api/appsettings.json
@@ -418,7 +418,7 @@
     },
     "Visits": {
       "Id": "33333333-3333-4333-8333-333333333333",
-      "Name": "LSRP",
+      "Name": "Visits",
       "ApplicationReference": {
         "Prefix": "VST"
       },


### PR DESCRIPTION
Add RG Visits prod config and bump version to 1.3.3

Updated CHANGELOG for 1.3.3 with RG Visits prod appsettings.
Bumped version in csproj to 1.3.3.
Added full Visits config to appsettings.Production.json.
Renamed Visits name in appsettings.json from LSRP to Visits.